### PR TITLE
Add AssertPromise trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-build
+build/
+vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ composer require seregazhuk/react-promise-testing --dev
 ```
 
 ## Quick Start
-Just extend your test classes from `seregazhuk\React\PromiseTesting\TestCase` class, 
-which itself extends PHPUnit `TestCase`:
- 
+Use the trait `seregazhuk\React\PromiseTesting\AssertPromise` or extend your
+test classes from `seregazhuk\React\PromiseTesting\TestCase` class,
+which itself extends PHPUnit `TestCase`.
+
 ```php
 final class MyTest extends TestCase
 {

--- a/src/AssertPromise.php
+++ b/src/AssertPromise.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace seregazhuk\React\PromiseTesting;
+
+use Clue\React\Block;
+use Exception;
+use PHPUnit\Framework\AssertionFailedError;
+use React\EventLoop\Factory as LoopFactory;
+use React\EventLoop\LoopInterface;
+use React\Promise\PromiseInterface;
+use React\Promise\Timer\TimeoutException;
+
+trait AssertPromise
+{
+    protected $defaultWaitTimeout = 2;
+
+    private $loop;
+
+    /**
+     * @param PromiseInterface $promise
+     * @param int|null $timeout seconds to wait for resolving
+     * @throws AssertionFailedError
+     */
+    public function assertPromiseFulfills(PromiseInterface $promise, int $timeout = null): void
+    {
+        $failMessage = 'Failed asserting that promise fulfills. ';
+        $this->addToAssertionCount(1);
+
+        try {
+            $this->waitForPromise($promise, $timeout);
+        } catch (TimeoutException $exception) {
+            $this->fail($failMessage . 'Promise was cancelled due to timeout.');
+        } catch (Exception $exception) {
+            $this->fail($failMessage . 'Promise was rejected.');
+        }
+    }
+
+    /**
+     * @param PromiseInterface $promise
+     * @param mixed $value
+     * @param int|null $timeout
+     * @throws AssertionFailedError
+     */
+    public function assertPromiseFulfillsWith(PromiseInterface $promise, $value, int $timeout = null): void
+    {
+        $failMessage = 'Failed asserting that promise fulfills with a specified value. ';
+        $result = null;
+        $this->addToAssertionCount(1);
+
+        try {
+            $result = $this->waitForPromise($promise, $timeout);
+        } catch (TimeoutException $exception) {
+            $this->fail($failMessage . 'Promise was cancelled due to timeout.');
+        } catch (Exception $exception) {
+            $this->fail($failMessage . 'Promise was rejected.');
+        }
+
+        $this->assertEquals($value, $result, $failMessage);
+    }
+
+    /**
+     * @throws AssertionFailedError
+     */
+    public function assertPromiseFulfillsWithInstanceOf(PromiseInterface $promise, string $class, int $timeout = null): void
+    {
+        $failMessage = "Failed asserting that promise fulfills with a value of class $class. ";
+        $result = null;
+        $this->addToAssertionCount(1);
+
+        try {
+            $result = $this->waitForPromise($promise, $timeout);
+        } catch (TimeoutException $exception) {
+            $this->fail($failMessage . 'Promise was cancelled due to timeout.');
+        } catch (Exception $exception) {
+            $this->fail($failMessage . 'Promise was rejected.');
+        }
+
+        $this->assertInstanceOf($class, $result, $failMessage);
+    }
+
+    /**
+     * @param PromiseInterface $promise
+     * @param int|null $timeout
+     * @throws AssertionFailedError
+     */
+    public function assertPromiseRejects(PromiseInterface $promise, int $timeout = null): void
+    {
+        $this->addToAssertionCount(1);
+
+        try {
+            $this->waitForPromise($promise, $timeout);
+        } catch (Exception $exception) {
+            return;
+        }
+
+        $this->fail('Failed asserting that promise rejects. Promise was fulfilled.');
+    }
+
+    /**
+     * @throws AssertionFailedError
+     */
+    public function assertPromiseRejectsWith(PromiseInterface $promise, string $reasonExceptionClass, int $timeout = null): void
+    {
+        try {
+            $this->waitForPromise($promise, $timeout);
+        } catch (Exception $reason) {
+            $this->assertInstanceOf(
+                $reasonExceptionClass, $reason, 'Failed asserting that promise rejects with a specified reason.'
+            );
+        }
+
+        $this->fail('Failed asserting that promise rejects. Promise was fulfilled.');
+    }
+
+    /**
+     * @throws Exception
+     * @return mixed
+     */
+    public function waitForPromiseToFulfill(PromiseInterface $promise, int $timeout = null)
+    {
+        try {
+            return $this->waitForPromise($promise, $timeout);
+        } catch (Exception $exception) {
+            $reason = get_class($exception);
+            $this->fail("Failed to fulfill a promise. It was rejected with {$reason}.");
+        }
+    }
+
+    /**
+     * @return mixed
+     * @throws Exception
+     */
+    public function waitForPromise(PromiseInterface $promise, int $timeout = null)
+    {
+        return Block\await($promise, $this->eventLoop(), $timeout ?: $this->defaultWaitTimeout);
+    }
+
+    public function eventLoop(): LoopInterface
+    {
+        if (! $this->loop) {
+            $this->loop = LoopFactory::create();
+        }
+
+        return $this->loop;
+    }
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -2,147 +2,16 @@
 
 namespace seregazhuk\React\PromiseTesting;
 
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
-use React\EventLoop\LoopInterface;
-use React\Promise\PromiseInterface;
-use Clue\React\Block;
-use Exception;
-use React\EventLoop\Factory as LoopFactory;
-use React\Promise\Timer\TimeoutException;
 
 abstract class TestCase extends PHPUnitTestCase
 {
-    private const DEFAULT_WAIT_TIMEOUT = 2;
-
-    private $loop;
+    use AssertPromise;
 
     protected function setUp(): void
     {
-        $this->loop = LoopFactory::create();
-    }
+        parent::setUp();
 
-    /**
-     * @param PromiseInterface $promise
-     * @param int|null $timeout seconds to wait for resolving
-     * @throws AssertionFailedError
-     */
-    public function assertPromiseFulfills(PromiseInterface $promise, int $timeout = null): void
-    {
-        $failMessage = 'Failed asserting that promise fulfills. ';
-        $this->addToAssertionCount(1);
-
-        try {
-            $this->waitForPromise($promise, $timeout);
-        } catch (TimeoutException $exception) {
-            $this->fail($failMessage . 'Promise was cancelled due to timeout.');
-        } catch (Exception $exception) {
-            $this->fail($failMessage . 'Promise was rejected.');
-        }
-    }
-
-    /**
-     * @param PromiseInterface $promise
-     * @param mixed $value
-     * @param int|null $timeout
-     * @throws AssertionFailedError
-     */
-    public function assertPromiseFulfillsWith(PromiseInterface $promise, $value, int $timeout = null): void
-    {
-        $failMessage = 'Failed asserting that promise fulfills with a specified value. ';
-        $result = null;
-        $this->addToAssertionCount(1);
-
-        try {
-            $result = $this->waitForPromise($promise, $timeout);
-        } catch (TimeoutException $exception) {
-            $this->fail($failMessage . 'Promise was cancelled due to timeout.');
-        } catch (Exception $exception) {
-            $this->fail($failMessage . 'Promise was rejected.');
-        }
-
-        $this->assertEquals($value, $result, $failMessage);
-    }
-
-    /**
-     * @throws AssertionFailedError
-     */
-    public function assertPromiseFulfillsWithInstanceOf(PromiseInterface $promise, string $class, int $timeout = null): void
-    {
-        $failMessage = "Failed asserting that promise fulfills with a value of class $class. ";
-        $result = null;
-        $this->addToAssertionCount(1);
-
-        try {
-            $result = $this->waitForPromise($promise, $timeout);
-        } catch (TimeoutException $exception) {
-            $this->fail($failMessage . 'Promise was cancelled due to timeout.');
-        } catch (Exception $exception) {
-            $this->fail($failMessage . 'Promise was rejected.');
-        }
-
-        $this->assertInstanceOf($class, $result, $failMessage);
-    }
-
-    /**
-     * @param PromiseInterface $promise
-     * @param int|null $timeout
-     * @throws AssertionFailedError
-     */
-    public function assertPromiseRejects(PromiseInterface $promise, int $timeout = null): void
-    {
-        $this->addToAssertionCount(1);
-
-        try {
-            $this->waitForPromise($promise, $timeout);
-        } catch (Exception $exception) {
-            return;
-        }
-
-        $this->fail('Failed asserting that promise rejects. Promise was fulfilled.');
-    }
-
-    /**
-     * @throws AssertionFailedError
-     */
-    public function assertPromiseRejectsWith(PromiseInterface $promise, string $reasonExceptionClass, int $timeout = null): void
-    {
-        try {
-            $this->waitForPromise($promise, $timeout);
-        } catch (Exception $reason) {
-            $this->assertInstanceOf(
-                $reasonExceptionClass, $reason, 'Failed asserting that promise rejects with a specified reason.'
-            );
-        }
-
-        $this->fail('Failed asserting that promise rejects. Promise was fulfilled.');
-    }
-
-    /**
-     * @throws Exception
-     * @return mixed
-     */
-    public function waitForPromiseToFulfill(PromiseInterface $promise, int $timeout = null)
-    {
-        try {
-            return $this->waitForPromise($promise, $timeout);
-        } catch (Exception $exception) {
-            $reason = get_class($exception);
-            $this->fail("Failed to fulfill a promise. It was rejected with {$reason}.");
-        }
-    }
-
-    /**
-     * @return mixed
-     * @throws Exception
-     */
-    public function waitForPromise(PromiseInterface $promise, int $timeout = null)
-    {
-        return Block\await($promise, $this->loop, $timeout ?: self::DEFAULT_WAIT_TIMEOUT);
-    }
-
-    public function eventLoop(): LoopInterface
-    {
-        return $this->loop;
+        $this->eventLoop();
     }
 }


### PR DESCRIPTION
Sometimes you can't or don't want to extend a class in your test class.
This makes it possible to use the package without the requirement of extending `TestCase`.
